### PR TITLE
Implement user registration with profiles

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,12 @@ if __name__ == "__main__":
         admin = User.query.filter_by(username=Config.ADMIN_USERNAME).first()
         if not admin:
             print("[*] Admin not found, creating...")
-            admin = User(username=Config.ADMIN_USERNAME)
+            admin = User(
+                username=Config.ADMIN_USERNAME,
+                nombre="Administrador",
+                email="admin@example.com",
+                perfil="Admin",
+            )
             admin.set_password(Config.ADMIN_PASSWORD)
             db.session.add(admin)
             db.session.commit()

--- a/models/models.py
+++ b/models/models.py
@@ -6,6 +6,9 @@ from werkzeug.security import generate_password_hash, check_password_hash
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
+    nombre = db.Column(db.String(120), nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    perfil = db.Column(db.String(50), nullable=False, default="Vendedor")
     password_hash = db.Column(db.String(128), nullable=False)
 
     def set_password(self, password: str):

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -3,10 +3,43 @@ from flask_login import login_user, logout_user, login_required
 from models.models import User
 from flask_login import current_user  # ya que usás user logueado
 from werkzeug.security import generate_password_hash
+from extensions import db
 
 
 
 auth_routes = Blueprint('auth_routes', __name__, template_folder='../templates')
+
+
+@auth_routes.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        nombre = request.form['nombre']
+        email = request.form['email']
+        perfil = request.form.get('perfil', 'Vendedor')
+
+        if User.query.filter_by(username=username).first():
+            flash('El nombre de usuario ya existe.')
+            return redirect(url_for('auth_routes.register'))
+
+        if User.query.filter_by(email=email).first():
+            flash('El email ya está registrado.')
+            return redirect(url_for('auth_routes.register'))
+
+        nuevo = User(
+            username=username,
+            nombre=nombre,
+            email=email,
+            perfil=perfil,
+        )
+        nuevo.set_password(password)
+        db.session.add(nuevo)
+        db.session.commit()
+        flash('Usuario creado correctamente.')
+        return redirect(url_for('auth_routes.login'))
+
+    return render_template('register.html')
 
 @auth_routes.route('/login', methods=['GET', 'POST'])
 def login():

--- a/templates/login.html
+++ b/templates/login.html
@@ -11,5 +11,9 @@
     <input type="password" name="password" class="border px-2 py-1 w-full" required>
   </div>
   <button type="submit" class="bg-blue-500 text-white px-4 py-2">Entrar</button>
+  <p class="mt-2 text-sm">
+    ¿No tenés cuenta?
+    <a href="{{ url_for('auth_routes.register') }}" class="text-blue-500 underline">Registrate</a>
+  </p>
 </form>
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="text-xl font-bold mb-4">Crear usuario</h2>
+<form method="post" class="space-y-4 max-w-sm">
+  <div>
+    <label class="block">Usuario</label>
+    <input type="text" name="username" class="border px-2 py-1 w-full" required>
+  </div>
+  <div>
+    <label class="block">Nombre</label>
+    <input type="text" name="nombre" class="border px-2 py-1 w-full" required>
+  </div>
+  <div>
+    <label class="block">Email</label>
+    <input type="email" name="email" class="border px-2 py-1 w-full" required>
+  </div>
+  <div>
+    <label class="block">Perfil</label>
+    <select name="perfil" class="border px-2 py-1 w-full">
+      <option value="Vendedor">Vendedor</option>
+      <option value="Admin">Admin</option>
+    </select>
+  </div>
+  <div>
+    <label class="block">Contraseña</label>
+    <input type="password" name="password" class="border px-2 py-1 w-full" required>
+  </div>
+  <button type="submit" class="bg-blue-500 text-white px-4 py-2">Guardar</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `nombre`, `email` and `perfil` fields to `User` model
- create new register route and template
- link register page from login
- seed admin user with full data

## Testing
- `python -m py_compile models/models.py routes/auth.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef5e3c01c83219ed7a48ca9350896