### PR TITLE
Fix DB config fallback

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,12 @@ class Config:
 
     # Base de datos: Supabase
     DB_PATH = os.path.join(BASEDIR, 'database', 'ventas.db')
-    SQLALCHEMY_DATABASE_URI = os.environ["SQLALCHEMY_DATABASE_URI"]
+    SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI")
+    if not SQLALCHEMY_DATABASE_URI:
+        SQLALCHEMY_DATABASE_URI = f"sqlite:///{DB_PATH}"
+        print(
+            f"[!] SQLALCHEMY_DATABASE_URI not set. Using SQLite database at {SQLALCHEMY_DATABASE_URI}"
+        )
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 


### PR DESCRIPTION
## Summary
- use `os.getenv()` for `SQLALCHEMY_DATABASE_URI`
- warn and fallback to SQLite when env var is missing

## Testing
- `python -m py_compile config.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6856d9409b008321a00bc457e11de7b2