### PR TITLE
Ensure SECRET_KEY env var is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# LaPaz Store Web App
+
+This project requires several environment variables to run correctly. In particular, `SECRET_KEY` **must** be defined. It is used by Flask and extensions for sessions and CSRF protection.
+
+Set the variable before starting the application:
+
+```bash
+export SECRET_KEY="a-very-secret-string"
+```
+
+The app will refuse to start in production if this variable is missing. In development mode (`FLASK_ENV=development`) a temporary secret key will be generated automatically.
+

--- a/config.py
+++ b/config.py
@@ -14,7 +14,14 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     # Seguridad y archivos
-    SECRET_KEY = os.environ.get("SECRET_KEY") or secrets.token_hex(16)
+    # "SECRET_KEY" debe estar definido en el entorno para producción.
+    # Si FLASK_ENV=development y no se definió, se genera uno temporal.
+    SECRET_KEY = os.environ.get("SECRET_KEY")
+    if not SECRET_KEY:
+        if os.environ.get("FLASK_ENV") == "development":
+            SECRET_KEY = secrets.token_hex(16)
+        else:
+            raise RuntimeError("SECRET_KEY environment variable is required")
     UPLOAD_FOLDER = os.path.join(BASEDIR, 'static', 'uploads')
     MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10 MB
 


### PR DESCRIPTION
## Summary
- clarify need for `SECRET_KEY` in new README
- generate temporary key only in development

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`

------
https://chatgpt.com/codex/tasks/task_e_6856d94d6bb483219afaf8197be5dd74