### PR TITLE
Update Python version and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ export SECRET_KEY="a-very-secret-string"
 
 The app will refuse to start in production if this variable is missing. In development mode (`FLASK_ENV=development`) a temporary secret key will be generated automatically.
 
+## Python version
+
+Render currently supports several versions of Python, including 3.11 and 3.12. This
+project targets **Python 3.11** to ensure compatibility with all dependencies.
+The deployment configuration in `render.yaml` specifies this version.
+
+When installing dependencies on Render, we use the `psycopg2-binary` package so a
+prebuilt wheel can be used instead of compiling `psycopg2` from source. This avoids
+build errors during deployment.
+

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,9 @@ services:
   - type: web
     name: lapaz-store
     runtime: python
-    pythonVersion: 3.12.3
+    # Render supports several versions of Python. This project targets Python 3.11
+    # to avoid compatibility issues with certain dependencies.
+    pythonVersion: 3.11
     buildCommand: "pip install -r requirements.txt"
     startCommand: "gunicorn app:app"
     envVars:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ Flask-Login==0.6.3
 SQLAlchemy==2.0.41
 python-dotenv==1.1.0
 gunicorn==23.0.0
-psycopg2==2.9.9
+# Use the precompiled binary wheel to avoid build errors during deployment.
+psycopg2-binary==2.9.9
 supabase==1.0.3
 
 # Data handling


### PR DESCRIPTION
## Summary
- target Python 3.11 in Render configuration
- use `psycopg2-binary` instead of source build
- document Python version choice and psycopg2-binary in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856db527ef083219e44f1629d8b052d