### PR TITLE
Fix DB init by importing Flask app

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -1,8 +1,6 @@
-from app import create_app
+from app import app
 from extensions import db
 from models.models import *
-
-app = create_app()
 
 with app.app_context():
     db.create_all()


### PR DESCRIPTION
## Summary
- update `init_db.py` to import the configured Flask `app`

## Testing
- `python init_db.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install Flask Flask-SQLAlchemy flask-login` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684f0bbfeff48321befecbd30705cf24